### PR TITLE
Rewop

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,6 @@ version = "0.1.0"
 
 [deps]
 BinaryProvider = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
-Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
 LasIO = "570499db-eae3-5eb6-bdd5-a5326f375e68"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 
 # LazIO
-Extends LasIO with Laszip integration.
+Extends LasIO with LASzip integration.
 
-Uses the [LASzip](https://github.com/LASzip/LASzip/) shared library to read compressed las files (*.laz) into the uncompressed format that [LasIO](https://github.com/visr/LasIO.jl) reads natively.
+Uses the [LASzip](https://github.com/LASzip/LASzip/) shared library to read compressed las files (\*.laz) into the uncompressed format that [LasIO](https://github.com/visr/LasIO.jl) reads natively.
 
 ```julia
 using LazIO
@@ -40,5 +40,3 @@ end
 sum ./ ds.header.number_of_point_records
 (3497.988658107152, 3741.789882541163, -164.49942114741447)
 ```
-
-For the moment this wrapper only supports reading.

--- a/REQUIRE
+++ b/REQUIRE
@@ -3,4 +3,3 @@ FileIO
 Parameters
 LasIO 0.2.0
 BinaryProvider
-Compat

--- a/src/convert.jl
+++ b/src/convert.jl
@@ -1,7 +1,5 @@
 # Here be all conversions from Laszip C Types to LasIO types
 
-import Base.convert
-
 "Conversion to LasIO header"
 LasHeader(h::laszip_header) =
     LasIO.LasHeader(
@@ -41,7 +39,7 @@ LasHeader(h::laszip_header) =
     )
 
 "ASPRS LAS point data record format 0"
-convert(::Type{LasPoint0}, p::laszip_point) =
+Base.convert(::Type{LasPoint0}, p::laszip_point) =
     LasPoint0(
         p.X,
         p.Y,
@@ -55,7 +53,7 @@ convert(::Type{LasPoint0}, p::laszip_point) =
     )
 
 "ASPRS LAS point data record format 1"
-convert(::Type{LasPoint1}, p::laszip_point) =
+Base.convert(::Type{LasPoint1}, p::laszip_point) =
     LasPoint1(
         p.X,
         p.Y,
@@ -70,7 +68,7 @@ convert(::Type{LasPoint1}, p::laszip_point) =
     )
 
 "ASPRS LAS point data record format 2"
-convert(::Type{LasPoint2}, p::laszip_point) =
+Base.convert(::Type{LasPoint2}, p::laszip_point) =
     LasPoint2(
         p.X,
         p.Y,
@@ -87,7 +85,7 @@ convert(::Type{LasPoint2}, p::laszip_point) =
     )
 
 "ASPRS LAS point data record format 3"
-convert(::Type{LasPoint3}, p::laszip_point) =
+Base.convert(::Type{LasPoint3}, p::laszip_point) =
     LasPoint3(
         p.X,
         p.Y,

--- a/src/convert.jl
+++ b/src/convert.jl
@@ -1,7 +1,7 @@
 # Here be all conversions from Laszip C Types to LasIO types
 
 "Conversion to LasIO header"
-LasHeader(h::laszip_header) =
+LasHeader(h::LazHeader) =
     LasIO.LasHeader(
         h.file_source_ID,
         h.global_encoding,
@@ -39,7 +39,7 @@ LasHeader(h::laszip_header) =
     )
 
 "ASPRS LAS point data record format 0"
-Base.convert(::Type{LasPoint0}, p::laszip_point) =
+Base.convert(::Type{LasPoint0}, p::LazPoint) =
     LasPoint0(
         p.X,
         p.Y,
@@ -53,7 +53,7 @@ Base.convert(::Type{LasPoint0}, p::laszip_point) =
     )
 
 "ASPRS LAS point data record format 1"
-Base.convert(::Type{LasPoint1}, p::laszip_point) =
+Base.convert(::Type{LasPoint1}, p::LazPoint) =
     LasPoint1(
         p.X,
         p.Y,
@@ -68,7 +68,7 @@ Base.convert(::Type{LasPoint1}, p::laszip_point) =
     )
 
 "ASPRS LAS point data record format 2"
-Base.convert(::Type{LasPoint2}, p::laszip_point) =
+Base.convert(::Type{LasPoint2}, p::LazPoint) =
     LasPoint2(
         p.X,
         p.Y,
@@ -85,7 +85,7 @@ Base.convert(::Type{LasPoint2}, p::laszip_point) =
     )
 
 "ASPRS LAS point data record format 3"
-Base.convert(::Type{LasPoint3}, p::laszip_point) =
+Base.convert(::Type{LasPoint3}, p::LazPoint) =
     LasPoint3(
         p.X,
         p.Y,

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -12,7 +12,7 @@ end
 
 function open(f::AbstractString)
     # Setup laszip reader
-    laszip_reader = Ref{Ptr{Nothing}}()
+    laszip_reader = Ref{Ptr{Cvoid}}()
     @check laszip_reader[] laszip_create(laszip_reader)
 
     # Open lasfile

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -1,8 +1,8 @@
 struct LazDataset
     filename::String
     filehandle::Ptr{Cvoid}
-    header::laszip_header  # this enables iterating without unsafe_load everytime
-    point::Ptr{laszip_point}
+    header::LazHeader  # this enables iterating without unsafe_load everytime
+    point::Ptr{LazPoint}
 end
 
 function Base.show(io::IO, ds::LazDataset)
@@ -19,12 +19,12 @@ function open(f::AbstractString)
     @check laszip_reader[] laszip_open_reader(laszip_reader[], f, Ref{Cint}(0))
 
     # Get a pointer to the header
-    header_ptr = Ref{Ptr{laszip_header}}()
+    header_ptr = Ref{Ptr{LazHeader}}()
     @check laszip_reader[] laszip_get_header_pointer(laszip_reader[], header_ptr)
     header = unsafe_load(header_ptr[])
 
     # Get a pointer to the points that will be read
-    point_ptr = Ref{Ptr{laszip_point}}()
+    point_ptr = Ref{Ptr{LazPoint}}()
     @check laszip_reader[] laszip_get_point_pointer(laszip_reader[], point_ptr)
 
     LazDataset(f, laszip_reader[], header, point_ptr[])
@@ -52,7 +52,7 @@ function Base.iterate(ds::LazDataset)
     end
 end
 
-Base.eltype(::LazDataset) = laszip_point
+Base.eltype(::LazDataset) = LazPoint
 Base.length(ds::LazDataset) = Int(ds.header.number_of_point_records)
 
 function Base.close(ds::LazDataset)

--- a/src/fileio.jl
+++ b/src/fileio.jl
@@ -5,7 +5,7 @@ loadheader(f::File{format"LAZ_"}) = loadheader(f.filename)
 
 function loadheader(f::String)
     # Setup laszip reader
-    laszip_reader = Ref{Ptr{Nothing}}()
+    laszip_reader = Ref{Ptr{Cvoid}}()
     @check laszip_reader[] laszip_create(laszip_reader)
 
     # Open lasfile
@@ -39,7 +39,7 @@ function load(f::String; range::Union{UnitRange{T}, Integer, Colon, Array{T, 1}}
     @info "LASzip DLL $(version_major[]) $(version_minor[]) $(version_revision[]) (build $(version_build[]))"
 
     # Setup laszip reader
-    laszip_reader = Ref{Ptr{Nothing}}()
+    laszip_reader = Ref{Ptr{Cvoid}}()
     @check laszip_reader[] laszip_create(laszip_reader)
 
     # Open lasfile

--- a/src/fileio.jl
+++ b/src/fileio.jl
@@ -14,7 +14,7 @@ function loadheader(f::String)
     is_compressed[] == 0 ? nothing : @info "File $f is compressed"
 
     # Get header
-    header_ptr = Ref{Ptr{laszip_header}}()
+    header_ptr = Ref{Ptr{LazHeader}}()
     @check laszip_reader[] laszip_get_header_pointer(laszip_reader[], header_ptr)
     header = LasHeader(unsafe_load(header_ptr[]))
 
@@ -48,12 +48,12 @@ function load(f::String; range::Union{UnitRange{T}, Integer, Colon, Array{T, 1}}
     is_compressed[] == 0 ? nothing : @info "File $f is compressed"
 
     # Get header
-    header_ptr = Ref{Ptr{laszip_header}}()
+    header_ptr = Ref{Ptr{LazHeader}}()
     @check laszip_reader[] laszip_get_header_pointer(laszip_reader[], header_ptr)
     header = LasHeader(unsafe_load(header_ptr[]))
 
     # Get a pointer to the points that will be read
-    point_ptr = Ref{Ptr{laszip_point}}()
+    point_ptr = Ref{Ptr{LazPoint}}()
     @check laszip_reader[] laszip_get_point_pointer(laszip_reader[], point_ptr)
 
     n = header.records_count

--- a/src/laszip.jl
+++ b/src/laszip.jl
@@ -61,7 +61,7 @@ const laszip = replace(liblaszip, "_api" => "")
 # end
 
 # function fread(__ptr, __size::Csize_t, __nitems::Csize_t, __stream)
-#     ccall((:fread, laszip), Csize_t, (Ptr{Nothing}, Csize_t, Csize_t, Ptr{FILE}), __ptr, __size, __nitems, __stream)
+#     ccall((:fread, laszip), Csize_t, (Ptr{Cvoid}, Csize_t, Csize_t, Ptr{FILE}), __ptr, __size, __nitems, __stream)
 # end
 
 # function freopen(arg1, arg2, arg3)
@@ -81,7 +81,7 @@ const laszip = replace(liblaszip, "_api" => "")
 # end
 
 # function fwrite(__ptr, __size::Csize_t, __nitems::Csize_t, __stream)
-#     ccall((:fwrite, laszip), Csize_t, (Ptr{Nothing}, Csize_t, Csize_t, Ptr{FILE}), __ptr, __size, __nitems, __stream)
+#     ccall((:fwrite, laszip), Csize_t, (Ptr{Cvoid}, Csize_t, Csize_t, Ptr{FILE}), __ptr, __size, __nitems, __stream)
 # end
 
 # function getc(arg1)
@@ -285,7 +285,7 @@ const laszip = replace(liblaszip, "_api" => "")
 # end
 
 # function funopen(arg1, arg2, arg3, arg4, arg5)
-#     ccall((:funopen, laszip), Ptr{FILE}, (Ptr{Nothing}, Ptr{Nothing}, Ptr{Nothing}, Ptr{Nothing}, Ptr{Nothing}), arg1, arg2, arg3, arg4, arg5)
+#     ccall((:funopen, laszip), Ptr{FILE}, (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}), arg1, arg2, arg3, arg4, arg5)
 # end
 
 function laszip_get_version(version_major, version_minor, version_revision, version_build)

--- a/src/laszip.jl
+++ b/src/laszip.jl
@@ -41,7 +41,7 @@ const laszip = replace(liblaszip, "_api" => "")
 # end
 
 # function fgetpos(arg1, arg2)
-#     ccall((:fgetpos, laszip), Cint, (Ptr{Cvoid}, Ptr{fpos_t}), arg1, arg2)
+#     ccall((:fgetpos, laszip), Cint, (Ptr{Cvoid}, Ptr{Int64}), arg1, arg2)
 # end
 
 # function fgets(arg1, arg2::Cint, arg3)
@@ -73,7 +73,7 @@ const laszip = replace(liblaszip, "_api" => "")
 # end
 
 # function fsetpos(arg1, arg2)
-#     ccall((:fsetpos, laszip), Cint, (Ptr{Cvoid}, Ptr{fpos_t}), arg1, arg2)
+#     ccall((:fsetpos, laszip), Cint, (Ptr{Cvoid}, Ptr{Int64}), arg1, arg2)
 # end
 
 # function ftell(arg1)
@@ -144,8 +144,8 @@ const laszip = replace(liblaszip, "_api" => "")
 #     ccall((:ungetc, laszip), Cint, (Cint, Ptr{Cvoid}), arg1, arg2)
 # end
 
-# function vfprintf(arg1, arg2, arg3::va_list)
-#     ccall((:vfprintf, laszip), Cint, (Ptr{Cvoid}, Cstring, va_list), arg1, arg2, arg3)
+# function vfprintf(arg1, arg2, arg3::Cstring)
+#     ccall((:vfprintf, laszip), Cint, (Ptr{Cvoid}, Cstring, Cstring), arg1, arg2, arg3)
 # end
 
 # function vprintf(arg1, arg2)
@@ -216,12 +216,12 @@ const laszip = replace(liblaszip, "_api" => "")
 #     ccall((:tempnam, laszip), Cstring, (Cstring, Cstring), __dir, __prefix)
 # end
 
-# function fseeko(__stream, __offset::off_t, __whence::Cint)
-#     ccall((:fseeko, laszip), Cint, (Ptr{Cvoid}, off_t, Cint), __stream, __offset, __whence)
+# function fseeko(__stream, __offset::Int64, __whence::Cint)
+#     ccall((:fseeko, laszip), Cint, (Ptr{Cvoid}, Int64, Cint), __stream, __offset, __whence)
 # end
 
 # function ftello(__stream)
-#     ccall((:ftello, laszip), off_t, (Ptr{Cvoid},), __stream)
+#     ccall((:ftello, laszip), Int64, (Ptr{Cvoid},), __stream)
 # end
 
 # function vfscanf(__stream, __format, arg1)
@@ -240,16 +240,16 @@ const laszip = replace(liblaszip, "_api" => "")
 #     ccall((:vsscanf, laszip), Cint, (Cstring, Cstring, Ptr{__va_list_tag}), __str, __format, arg1)
 # end
 
-# function vdprintf(arg1::Cint, arg2, arg3::va_list)
-#     ccall((:vdprintf, laszip), Cint, (Cint, Cstring, va_list), arg1, arg2, arg3)
+# function vdprintf(arg1::Cint, arg2, arg3::Cstring)
+#     ccall((:vdprintf, laszip), Cint, (Cint, Cstring, Cstring), arg1, arg2, arg3)
 # end
 
 # function getdelim(__linep, __linecapp, __delimiter::Cint, __stream)
-#     ccall((:getdelim, laszip), ssize_t, (Ptr{Cstring}, Ptr{Csize_t}, Cint, Ptr{Cvoid}), __linep, __linecapp, __delimiter, __stream)
+#     ccall((:getdelim, laszip), Int32, (Ptr{Cstring}, Ptr{Csize_t}, Cint, Ptr{Cvoid}), __linep, __linecapp, __delimiter, __stream)
 # end
 
 # function getline(__linep, __linecapp, __stream)
-#     ccall((:getline, laszip), ssize_t, (Ptr{Cstring}, Ptr{Csize_t}, Ptr{Cvoid}), __linep, __linecapp, __stream)
+#     ccall((:getline, laszip), Int32, (Ptr{Cstring}, Ptr{Csize_t}, Ptr{Cvoid}), __linep, __linecapp, __stream)
 # end
 
 # function ctermid_r(arg1)
@@ -276,8 +276,8 @@ const laszip = replace(liblaszip, "_api" => "")
 #     ccall((:setlinebuf, laszip), Cint, (Ptr{Cvoid},), arg1)
 # end
 
-# function vasprintf(arg1, arg2, arg3::va_list)
-#     ccall((:vasprintf, laszip), Cint, (Ptr{Cstring}, Cstring, va_list), arg1, arg2, arg3)
+# function vasprintf(arg1, arg2, arg3::Cstring)
+#     ccall((:vasprintf, laszip), Cint, (Ptr{Cstring}, Cstring, Cstring), arg1, arg2, arg3)
 # end
 
 # function zopen(arg1, arg2, arg3::Cint)

--- a/src/laszip.jl
+++ b/src/laszip.jl
@@ -353,7 +353,7 @@ end
 # end
 
 # function laszip_set_geokeys(pointer::Ptr{Cvoid}, number::UInt32, key_entries)
-#     ccall((:laszip_set_geokeys, laszip), Int32, (Ptr{Cvoid}, UInt32, Ptr{laszip_geokey_struct}), pointer, number, key_entries)
+#     ccall((:laszip_set_geokeys, laszip), Int32, (Ptr{Cvoid}, UInt32, Ptr{Cvoid}), pointer, number, key_entries)
 # end
 
 # function laszip_set_geodouble_params(pointer::Ptr{Cvoid}, number::UInt32, geodouble_params)

--- a/src/laszip.jl
+++ b/src/laszip.jl
@@ -17,75 +17,75 @@ const laszip = replace(liblaszip, "_api" => "")
 # end
 
 # function clearerr(arg1)
-#     ccall((:clearerr, laszip), Nothing, (Ptr{FILE},), arg1)
+#     ccall((:clearerr, laszip), Nothing, (Ptr{Cvoid},), arg1)
 # end
 
 # function fclose(arg1)
-#     ccall((:fclose, laszip), Cint, (Ptr{FILE},), arg1)
+#     ccall((:fclose, laszip), Cint, (Ptr{Cvoid},), arg1)
 # end
 
 # function feof(arg1)
-#     ccall((:feof, laszip), Cint, (Ptr{FILE},), arg1)
+#     ccall((:feof, laszip), Cint, (Ptr{Cvoid},), arg1)
 # end
 
 # function ferror(arg1)
-#     ccall((:ferror, laszip), Cint, (Ptr{FILE},), arg1)
+#     ccall((:ferror, laszip), Cint, (Ptr{Cvoid},), arg1)
 # end
 
 # function fflush(arg1)
-#     ccall((:fflush, laszip), Cint, (Ptr{FILE},), arg1)
+#     ccall((:fflush, laszip), Cint, (Ptr{Cvoid},), arg1)
 # end
 
 # function fgetc(arg1)
-#     ccall((:fgetc, laszip), Cint, (Ptr{FILE},), arg1)
+#     ccall((:fgetc, laszip), Cint, (Ptr{Cvoid},), arg1)
 # end
 
 # function fgetpos(arg1, arg2)
-#     ccall((:fgetpos, laszip), Cint, (Ptr{FILE}, Ptr{fpos_t}), arg1, arg2)
+#     ccall((:fgetpos, laszip), Cint, (Ptr{Cvoid}, Ptr{fpos_t}), arg1, arg2)
 # end
 
 # function fgets(arg1, arg2::Cint, arg3)
-#     ccall((:fgets, laszip), Cstring, (Cstring, Cint, Ptr{FILE}), arg1, arg2, arg3)
+#     ccall((:fgets, laszip), Cstring, (Cstring, Cint, Ptr{Cvoid}), arg1, arg2, arg3)
 # end
 
 # function fopen(__filename, __mode)
-#     ccall((:fopen, laszip), Ptr{FILE}, (Cstring, Cstring), __filename, __mode)
+#     ccall((:fopen, laszip), Ptr{Cvoid}, (Cstring, Cstring), __filename, __mode)
 # end
 
 # function fputc(arg1::Cint, arg2)
-#     ccall((:fputc, laszip), Cint, (Cint, Ptr{FILE}), arg1, arg2)
+#     ccall((:fputc, laszip), Cint, (Cint, Ptr{Cvoid}), arg1, arg2)
 # end
 
 # function fputs(arg1, arg2)
-#     ccall((:fputs, laszip), Cint, (Cstring, Ptr{FILE}), arg1, arg2)
+#     ccall((:fputs, laszip), Cint, (Cstring, Ptr{Cvoid}), arg1, arg2)
 # end
 
 # function fread(__ptr, __size::Csize_t, __nitems::Csize_t, __stream)
-#     ccall((:fread, laszip), Csize_t, (Ptr{Cvoid}, Csize_t, Csize_t, Ptr{FILE}), __ptr, __size, __nitems, __stream)
+#     ccall((:fread, laszip), Csize_t, (Ptr{Cvoid}, Csize_t, Csize_t, Ptr{Cvoid}), __ptr, __size, __nitems, __stream)
 # end
 
 # function freopen(arg1, arg2, arg3)
-#     ccall((:freopen, laszip), Ptr{FILE}, (Cstring, Cstring, Ptr{FILE}), arg1, arg2, arg3)
+#     ccall((:freopen, laszip), Ptr{Cvoid}, (Cstring, Cstring, Ptr{Cvoid}), arg1, arg2, arg3)
 # end
 
 # function fseek(arg1, arg2::Clong, arg3::Cint)
-#     ccall((:fseek, laszip), Cint, (Ptr{FILE}, Clong, Cint), arg1, arg2, arg3)
+#     ccall((:fseek, laszip), Cint, (Ptr{Cvoid}, Clong, Cint), arg1, arg2, arg3)
 # end
 
 # function fsetpos(arg1, arg2)
-#     ccall((:fsetpos, laszip), Cint, (Ptr{FILE}, Ptr{fpos_t}), arg1, arg2)
+#     ccall((:fsetpos, laszip), Cint, (Ptr{Cvoid}, Ptr{fpos_t}), arg1, arg2)
 # end
 
 # function ftell(arg1)
-#     ccall((:ftell, laszip), Clong, (Ptr{FILE},), arg1)
+#     ccall((:ftell, laszip), Clong, (Ptr{Cvoid},), arg1)
 # end
 
 # function fwrite(__ptr, __size::Csize_t, __nitems::Csize_t, __stream)
-#     ccall((:fwrite, laszip), Csize_t, (Ptr{Cvoid}, Csize_t, Csize_t, Ptr{FILE}), __ptr, __size, __nitems, __stream)
+#     ccall((:fwrite, laszip), Csize_t, (Ptr{Cvoid}, Csize_t, Csize_t, Ptr{Cvoid}), __ptr, __size, __nitems, __stream)
 # end
 
 # function getc(arg1)
-#     ccall((:getc, laszip), Cint, (Ptr{FILE},), arg1)
+#     ccall((:getc, laszip), Cint, (Ptr{Cvoid},), arg1)
 # end
 
 # function getchar()
@@ -101,7 +101,7 @@ const laszip = replace(liblaszip, "_api" => "")
 # end
 
 # function putc(arg1::Cint, arg2)
-#     ccall((:putc, laszip), Cint, (Cint, Ptr{FILE}), arg1, arg2)
+#     ccall((:putc, laszip), Cint, (Cint, Ptr{Cvoid}), arg1, arg2)
 # end
 
 # function putchar(arg1::Cint)
@@ -121,19 +121,19 @@ const laszip = replace(liblaszip, "_api" => "")
 # end
 
 # function rewind(arg1)
-#     ccall((:rewind, laszip), Nothing, (Ptr{FILE},), arg1)
+#     ccall((:rewind, laszip), Nothing, (Ptr{Cvoid},), arg1)
 # end
 
 # function setbuf(arg1, arg2)
-#     ccall((:setbuf, laszip), Nothing, (Ptr{FILE}, Cstring), arg1, arg2)
+#     ccall((:setbuf, laszip), Nothing, (Ptr{Cvoid}, Cstring), arg1, arg2)
 # end
 
 # function setvbuf(arg1, arg2, arg3::Cint, arg4::Csize_t)
-#     ccall((:setvbuf, laszip), Cint, (Ptr{FILE}, Cstring, Cint, Csize_t), arg1, arg2, arg3, arg4)
+#     ccall((:setvbuf, laszip), Cint, (Ptr{Cvoid}, Cstring, Cint, Csize_t), arg1, arg2, arg3, arg4)
 # end
 
 # function tmpfile()
-#     ccall((:tmpfile, laszip), Ptr{FILE}, ())
+#     ccall((:tmpfile, laszip), Ptr{Cvoid}, ())
 # end
 
 # function tmpnam(arg1)
@@ -141,11 +141,11 @@ const laszip = replace(liblaszip, "_api" => "")
 # end
 
 # function ungetc(arg1::Cint, arg2)
-#     ccall((:ungetc, laszip), Cint, (Cint, Ptr{FILE}), arg1, arg2)
+#     ccall((:ungetc, laszip), Cint, (Cint, Ptr{Cvoid}), arg1, arg2)
 # end
 
 # function vfprintf(arg1, arg2, arg3::va_list)
-#     ccall((:vfprintf, laszip), Cint, (Ptr{FILE}, Cstring, va_list), arg1, arg2, arg3)
+#     ccall((:vfprintf, laszip), Cint, (Ptr{Cvoid}, Cstring, va_list), arg1, arg2, arg3)
 # end
 
 # function vprintf(arg1, arg2)
@@ -161,35 +161,35 @@ const laszip = replace(liblaszip, "_api" => "")
 # end
 
 # function fdopen(arg1::Cint, arg2)
-#     ccall((:fdopen, laszip), Ptr{FILE}, (Cint, Cstring), arg1, arg2)
+#     ccall((:fdopen, laszip), Ptr{Cvoid}, (Cint, Cstring), arg1, arg2)
 # end
 
 # function fileno(arg1)
-#     ccall((:fileno, laszip), Cint, (Ptr{FILE},), arg1)
+#     ccall((:fileno, laszip), Cint, (Ptr{Cvoid},), arg1)
 # end
 
 # function pclose(arg1)
-#     ccall((:pclose, laszip), Cint, (Ptr{FILE},), arg1)
+#     ccall((:pclose, laszip), Cint, (Ptr{Cvoid},), arg1)
 # end
 
 # function popen(arg1, arg2)
-#     ccall((:popen, laszip), Ptr{FILE}, (Cstring, Cstring), arg1, arg2)
+#     ccall((:popen, laszip), Ptr{Cvoid}, (Cstring, Cstring), arg1, arg2)
 # end
 
 # function flockfile(arg1)
-#     ccall((:flockfile, laszip), Nothing, (Ptr{FILE},), arg1)
+#     ccall((:flockfile, laszip), Nothing, (Ptr{Cvoid},), arg1)
 # end
 
 # function ftrylockfile(arg1)
-#     ccall((:ftrylockfile, laszip), Cint, (Ptr{FILE},), arg1)
+#     ccall((:ftrylockfile, laszip), Cint, (Ptr{Cvoid},), arg1)
 # end
 
 # function funlockfile(arg1)
-#     ccall((:funlockfile, laszip), Nothing, (Ptr{FILE},), arg1)
+#     ccall((:funlockfile, laszip), Nothing, (Ptr{Cvoid},), arg1)
 # end
 
 # function getc_unlocked(arg1)
-#     ccall((:getc_unlocked, laszip), Cint, (Ptr{FILE},), arg1)
+#     ccall((:getc_unlocked, laszip), Cint, (Ptr{Cvoid},), arg1)
 # end
 
 # function getchar_unlocked()
@@ -197,7 +197,7 @@ const laszip = replace(liblaszip, "_api" => "")
 # end
 
 # function putc_unlocked(arg1::Cint, arg2)
-#     ccall((:putc_unlocked, laszip), Cint, (Cint, Ptr{FILE}), arg1, arg2)
+#     ccall((:putc_unlocked, laszip), Cint, (Cint, Ptr{Cvoid}), arg1, arg2)
 # end
 
 # function putchar_unlocked(arg1::Cint)
@@ -205,11 +205,11 @@ const laszip = replace(liblaszip, "_api" => "")
 # end
 
 # function getw(arg1)
-#     ccall((:getw, laszip), Cint, (Ptr{FILE},), arg1)
+#     ccall((:getw, laszip), Cint, (Ptr{Cvoid},), arg1)
 # end
 
 # function putw(arg1::Cint, arg2)
-#     ccall((:putw, laszip), Cint, (Cint, Ptr{FILE}), arg1, arg2)
+#     ccall((:putw, laszip), Cint, (Cint, Ptr{Cvoid}), arg1, arg2)
 # end
 
 # function tempnam(__dir, __prefix)
@@ -217,15 +217,15 @@ const laszip = replace(liblaszip, "_api" => "")
 # end
 
 # function fseeko(__stream, __offset::off_t, __whence::Cint)
-#     ccall((:fseeko, laszip), Cint, (Ptr{FILE}, off_t, Cint), __stream, __offset, __whence)
+#     ccall((:fseeko, laszip), Cint, (Ptr{Cvoid}, off_t, Cint), __stream, __offset, __whence)
 # end
 
 # function ftello(__stream)
-#     ccall((:ftello, laszip), off_t, (Ptr{FILE},), __stream)
+#     ccall((:ftello, laszip), off_t, (Ptr{Cvoid},), __stream)
 # end
 
 # function vfscanf(__stream, __format, arg1)
-#     ccall((:vfscanf, laszip), Cint, (Ptr{FILE}, Cstring, Ptr{__va_list_tag}), __stream, __format, arg1)
+#     ccall((:vfscanf, laszip), Cint, (Ptr{Cvoid}, Cstring, Ptr{__va_list_tag}), __stream, __format, arg1)
 # end
 
 # function vscanf(__format, arg1)
@@ -245,11 +245,11 @@ const laszip = replace(liblaszip, "_api" => "")
 # end
 
 # function getdelim(__linep, __linecapp, __delimiter::Cint, __stream)
-#     ccall((:getdelim, laszip), ssize_t, (Ptr{Cstring}, Ptr{Csize_t}, Cint, Ptr{FILE}), __linep, __linecapp, __delimiter, __stream)
+#     ccall((:getdelim, laszip), ssize_t, (Ptr{Cstring}, Ptr{Csize_t}, Cint, Ptr{Cvoid}), __linep, __linecapp, __delimiter, __stream)
 # end
 
 # function getline(__linep, __linecapp, __stream)
-#     ccall((:getline, laszip), ssize_t, (Ptr{Cstring}, Ptr{Csize_t}, Ptr{FILE}), __linep, __linecapp, __stream)
+#     ccall((:getline, laszip), ssize_t, (Ptr{Cstring}, Ptr{Csize_t}, Ptr{Cvoid}), __linep, __linecapp, __stream)
 # end
 
 # function ctermid_r(arg1)
@@ -257,7 +257,7 @@ const laszip = replace(liblaszip, "_api" => "")
 # end
 
 # function fgetln(arg1, arg2)
-#     ccall((:fgetln, laszip), Cstring, (Ptr{FILE}, Ptr{Csize_t}), arg1, arg2)
+#     ccall((:fgetln, laszip), Cstring, (Ptr{Cvoid}, Ptr{Csize_t}), arg1, arg2)
 # end
 
 # function fmtcheck(arg1, arg2)
@@ -265,15 +265,15 @@ const laszip = replace(liblaszip, "_api" => "")
 # end
 
 # function fpurge(arg1)
-#     ccall((:fpurge, laszip), Cint, (Ptr{FILE},), arg1)
+#     ccall((:fpurge, laszip), Cint, (Ptr{Cvoid},), arg1)
 # end
 
 # function setbuffer(arg1, arg2, arg3::Cint)
-#     ccall((:setbuffer, laszip), Nothing, (Ptr{FILE}, Cstring, Cint), arg1, arg2, arg3)
+#     ccall((:setbuffer, laszip), Nothing, (Ptr{Cvoid}, Cstring, Cint), arg1, arg2, arg3)
 # end
 
 # function setlinebuf(arg1)
-#     ccall((:setlinebuf, laszip), Cint, (Ptr{FILE},), arg1)
+#     ccall((:setlinebuf, laszip), Cint, (Ptr{Cvoid},), arg1)
 # end
 
 # function vasprintf(arg1, arg2, arg3::va_list)
@@ -281,11 +281,11 @@ const laszip = replace(liblaszip, "_api" => "")
 # end
 
 # function zopen(arg1, arg2, arg3::Cint)
-#     ccall((:zopen, laszip), Ptr{FILE}, (Cstring, Cstring, Cint), arg1, arg2, arg3)
+#     ccall((:zopen, laszip), Ptr{Cvoid}, (Cstring, Cstring, Cint), arg1, arg2, arg3)
 # end
 
 # function funopen(arg1, arg2, arg3, arg4, arg5)
-#     ccall((:funopen, laszip), Ptr{FILE}, (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}), arg1, arg2, arg3, arg4, arg5)
+#     ccall((:funopen, laszip), Ptr{Cvoid}, (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}), arg1, arg2, arg3, arg4, arg5)
 # end
 
 function laszip_get_version(version_major, version_minor, version_revision, version_build)

--- a/src/laszip.jl
+++ b/src/laszip.jl
@@ -289,165 +289,165 @@ const laszip = replace(liblaszip, "_api" => "")
 # end
 
 function laszip_get_version(version_major, version_minor, version_revision, version_build)
-    ccall((:laszip_get_version, laszip), laszip_I32, (Ptr{laszip_U8}, Ptr{laszip_U8}, Ptr{laszip_U16}, Ptr{laszip_U32}), version_major, version_minor, version_revision, version_build)
+    ccall((:laszip_get_version, laszip), Int32, (Ptr{UInt8}, Ptr{UInt8}, Ptr{UInt16}, Ptr{UInt32}), version_major, version_minor, version_revision, version_build)
 end
 
-function laszip_create(pointer::Ref{laszip_POINTER})
-    ccall((:laszip_create, laszip), laszip_I32, (Ptr{laszip_POINTER},), pointer)
+function laszip_create(pointer::Ref{Ptr{Cvoid}})
+    ccall((:laszip_create, laszip), Int32, (Ptr{Ptr{Cvoid}},), pointer)
 end
 
-function laszip_get_error(pointer::laszip_POINTER, error)
-    ccall((:laszip_get_error, laszip), laszip_I32, (laszip_POINTER, Ptr{Cstring}), pointer, error)
+function laszip_get_error(pointer::Ptr{Cvoid}, error)
+    ccall((:laszip_get_error, laszip), Int32, (Ptr{Cvoid}, Ptr{Cstring}), pointer, error)
 end
 
-function laszip_get_warning(pointer::laszip_POINTER, warning)
-    ccall((:laszip_get_warning, laszip), laszip_I32, (laszip_POINTER, Ptr{Cstring}), pointer, warning)
+function laszip_get_warning(pointer::Ptr{Cvoid}, warning)
+    ccall((:laszip_get_warning, laszip), Int32, (Ptr{Cvoid}, Ptr{Cstring}), pointer, warning)
 end
 
-function laszip_clean(pointer::laszip_POINTER)
-    ccall((:laszip_clean, laszip), laszip_I32, (laszip_POINTER,), pointer)
+function laszip_clean(pointer::Ptr{Cvoid})
+    ccall((:laszip_clean, laszip), Int32, (Ptr{Cvoid},), pointer)
 end
 
-function laszip_destroy(pointer::laszip_POINTER)
-    ccall((:laszip_destroy, laszip), laszip_I32, (laszip_POINTER,), pointer)
+function laszip_destroy(pointer::Ptr{Cvoid})
+    ccall((:laszip_destroy, laszip), Int32, (Ptr{Cvoid},), pointer)
 end
 
-function laszip_get_header_pointer(pointer::laszip_POINTER, header_pointer)
-    ccall((:laszip_get_header_pointer, laszip), laszip_I32, (laszip_POINTER, Ref{Ptr{laszip_header}}), pointer, header_pointer)
+function laszip_get_header_pointer(pointer::Ptr{Cvoid}, header_pointer)
+    ccall((:laszip_get_header_pointer, laszip), Int32, (Ptr{Cvoid}, Ref{Ptr{laszip_header}}), pointer, header_pointer)
 end
 
-function laszip_get_point_pointer(pointer::laszip_POINTER, point_pointer)
-    ccall((:laszip_get_point_pointer, laszip), laszip_I32, (laszip_POINTER, Ref{Ptr{laszip_point}}), pointer, point_pointer)
+function laszip_get_point_pointer(pointer::Ptr{Cvoid}, point_pointer)
+    ccall((:laszip_get_point_pointer, laszip), Int32, (Ptr{Cvoid}, Ref{Ptr{laszip_point}}), pointer, point_pointer)
 end
 
-function laszip_get_point_count(pointer::laszip_POINTER, count)
-    ccall((:laszip_get_point_count, laszip), laszip_I32, (laszip_POINTER, Ptr{laszip_I64}), pointer, count)
+function laszip_get_point_count(pointer::Ptr{Cvoid}, count)
+    ccall((:laszip_get_point_count, laszip), Int32, (Ptr{Cvoid}, Ptr{Int64}), pointer, count)
 end
 
-function laszip_set_header(pointer::laszip_POINTER, header)
-    ccall((:laszip_set_header, laszip), laszip_I32, (laszip_POINTER, Ptr{laszip_header}), pointer, header)
+function laszip_set_header(pointer::Ptr{Cvoid}, header)
+    ccall((:laszip_set_header, laszip), Int32, (Ptr{Cvoid}, Ptr{laszip_header}), pointer, header)
 end
 
-# function laszip_set_point_type_and_size(pointer::laszip_POINTER, point_type::laszip_U8, point_size::laszip_U16)
-#     ccall((:laszip_set_point_type_and_size, laszip), laszip_I32, (laszip_POINTER, laszip_U8, laszip_U16), pointer, point_type, point_size)
+# function laszip_set_point_type_and_size(pointer::Ptr{Cvoid}, point_type::UInt8, point_size::UInt16)
+#     ccall((:laszip_set_point_type_and_size, laszip), Int32, (Ptr{Cvoid}, UInt8, UInt16), pointer, point_type, point_size)
 # end
 
-# function laszip_check_for_integer_overflow(pointer::laszip_POINTER)
-#     ccall((:laszip_check_for_integer_overflow, laszip), laszip_I32, (laszip_POINTER,), pointer)
+# function laszip_check_for_integer_overflow(pointer::Ptr{Cvoid})
+#     ccall((:laszip_check_for_integer_overflow, laszip), Int32, (Ptr{Cvoid},), pointer)
 # end
 
-# function laszip_auto_offset(pointer::laszip_POINTER)
-#     ccall((:laszip_auto_offset, laszip), laszip_I32, (laszip_POINTER,), pointer)
+# function laszip_auto_offset(pointer::Ptr{Cvoid})
+#     ccall((:laszip_auto_offset, laszip), Int32, (Ptr{Cvoid},), pointer)
 # end
 
-function laszip_set_point(pointer::laszip_POINTER, point)
-    ccall((:laszip_set_point, laszip), laszip_I32, (laszip_POINTER, Ptr{laszip_point}), pointer, point)
+function laszip_set_point(pointer::Ptr{Cvoid}, point)
+    ccall((:laszip_set_point, laszip), Int32, (Ptr{Cvoid}, Ptr{laszip_point}), pointer, point)
 end
 
-# function laszip_set_coordinates(pointer::laszip_POINTER, coordinates)
-#     ccall((:laszip_set_coordinates, laszip), laszip_I32, (laszip_POINTER, Ptr{laszip_F64}), pointer, coordinates)
+# function laszip_set_coordinates(pointer::Ptr{Cvoid}, coordinates)
+#     ccall((:laszip_set_coordinates, laszip), Int32, (Ptr{Cvoid}, Ptr{Float64}), pointer, coordinates)
 # end
 
-# function laszip_get_coordinates(pointer::laszip_POINTER, coordinates)
-#     ccall((:laszip_get_coordinates, laszip), laszip_I32, (laszip_POINTER, Ptr{laszip_F64}), pointer, coordinates)
+# function laszip_get_coordinates(pointer::Ptr{Cvoid}, coordinates)
+#     ccall((:laszip_get_coordinates, laszip), Int32, (Ptr{Cvoid}, Ptr{Float64}), pointer, coordinates)
 # end
 
-# function laszip_set_geokeys(pointer::laszip_POINTER, number::laszip_U32, key_entries)
-#     ccall((:laszip_set_geokeys, laszip), laszip_I32, (laszip_POINTER, laszip_U32, Ptr{laszip_geokey_struct}), pointer, number, key_entries)
+# function laszip_set_geokeys(pointer::Ptr{Cvoid}, number::UInt32, key_entries)
+#     ccall((:laszip_set_geokeys, laszip), Int32, (Ptr{Cvoid}, UInt32, Ptr{laszip_geokey_struct}), pointer, number, key_entries)
 # end
 
-# function laszip_set_geodouble_params(pointer::laszip_POINTER, number::laszip_U32, geodouble_params)
-#     ccall((:laszip_set_geodouble_params, laszip), laszip_I32, (laszip_POINTER, laszip_U32, Ptr{laszip_F64}), pointer, number, geodouble_params)
+# function laszip_set_geodouble_params(pointer::Ptr{Cvoid}, number::UInt32, geodouble_params)
+#     ccall((:laszip_set_geodouble_params, laszip), Int32, (Ptr{Cvoid}, UInt32, Ptr{Float64}), pointer, number, geodouble_params)
 # end
 
-# function laszip_set_geoascii_params(pointer::laszip_POINTER, number::laszip_U32, geoascii_params)
-#     ccall((:laszip_set_geoascii_params, laszip), laszip_I32, (laszip_POINTER, laszip_U32, Ptr{laszip_CHAR}), pointer, number, geoascii_params)
+# function laszip_set_geoascii_params(pointer::Ptr{Cvoid}, number::UInt32, geoascii_params)
+#     ccall((:laszip_set_geoascii_params, laszip), Int32, (Ptr{Cvoid}, UInt32, Ptr{UInt8}), pointer, number, geoascii_params)
 # end
 
-# function laszip_add_attribute(pointer::laszip_POINTER, _type::laszip_U32, name, description, scale::laszip_F64, offset::laszip_F64)
-#     ccall((:laszip_add_attribute, laszip), laszip_I32, (laszip_POINTER, laszip_U32, Ptr{laszip_CHAR}, Ptr{laszip_CHAR}, laszip_F64, laszip_F64), pointer, _type, name, description, scale, offset)
+# function laszip_add_attribute(pointer::Ptr{Cvoid}, _type::UInt32, name, description, scale::Float64, offset::Float64)
+#     ccall((:laszip_add_attribute, laszip), Int32, (Ptr{Cvoid}, UInt32, Ptr{UInt8}, Ptr{UInt8}, Float64, Float64), pointer, _type, name, description, scale, offset)
 # end
 
-# function laszip_add_vlr(pointer::laszip_POINTER, user_id, record_id::laszip_U16, record_length_after_header::laszip_U16, description, data)
-#     ccall((:laszip_add_vlr, laszip), laszip_I32, (laszip_POINTER, Ptr{laszip_CHAR}, laszip_U16, laszip_U16, Ptr{laszip_CHAR}, Ptr{laszip_U8}), pointer, user_id, record_id, record_length_after_header, description, data)
+# function laszip_add_vlr(pointer::Ptr{Cvoid}, user_id, record_id::UInt16, record_length_after_header::UInt16, description, data)
+#     ccall((:laszip_add_vlr, laszip), Int32, (Ptr{Cvoid}, Ptr{UInt8}, UInt16, UInt16, Ptr{UInt8}, Ptr{UInt8}), pointer, user_id, record_id, record_length_after_header, description, data)
 # end
 
-# function laszip_remove_vlr(pointer::laszip_POINTER, user_id, record_id::laszip_U16)
-#     ccall((:laszip_remove_vlr, laszip), laszip_I32, (laszip_POINTER, Ptr{laszip_CHAR}, laszip_U16), pointer, user_id, record_id)
+# function laszip_remove_vlr(pointer::Ptr{Cvoid}, user_id, record_id::UInt16)
+#     ccall((:laszip_remove_vlr, laszip), Int32, (Ptr{Cvoid}, Ptr{UInt8}, UInt16), pointer, user_id, record_id)
 # end
 
-# function laszip_create_spatial_index(pointer::laszip_POINTER, create::laszip_BOOL, append::laszip_BOOL)
-#     ccall((:laszip_create_spatial_index, laszip), laszip_I32, (laszip_POINTER, laszip_BOOL, laszip_BOOL), pointer, create, append)
+# function laszip_create_spatial_index(pointer::Ptr{Cvoid}, create::Cint, append::Cint)
+#     ccall((:laszip_create_spatial_index, laszip), Int32, (Ptr{Cvoid}, Cint, Cint), pointer, create, append)
 # end
 
-# function laszip_preserve_generating_software(pointer::laszip_POINTER, preserve::laszip_BOOL)
-#     ccall((:laszip_preserve_generating_software, laszip), laszip_I32, (laszip_POINTER, laszip_BOOL), pointer, preserve)
+# function laszip_preserve_generating_software(pointer::Ptr{Cvoid}, preserve::Cint)
+#     ccall((:laszip_preserve_generating_software, laszip), Int32, (Ptr{Cvoid}, Cint), pointer, preserve)
 # end
 
-# function laszip_request_native_extension(pointer::laszip_POINTER, request::laszip_BOOL)
-#     ccall((:laszip_request_native_extension, laszip), laszip_I32, (laszip_POINTER, laszip_BOOL), pointer, request)
+# function laszip_request_native_extension(pointer::Ptr{Cvoid}, request::Cint)
+#     ccall((:laszip_request_native_extension, laszip), Int32, (Ptr{Cvoid}, Cint), pointer, request)
 # end
 
-# function laszip_request_compatibility_mode(pointer::laszip_POINTER, request::laszip_BOOL)
-#     ccall((:laszip_request_compatibility_mode, laszip), laszip_I32, (laszip_POINTER, laszip_BOOL), pointer, request)
+# function laszip_request_compatibility_mode(pointer::Ptr{Cvoid}, request::Cint)
+#     ccall((:laszip_request_compatibility_mode, laszip), Int32, (Ptr{Cvoid}, Cint), pointer, request)
 # end
 
-# function laszip_set_chunk_size(pointer::laszip_POINTER, chunk_size::laszip_U32)
-#     ccall((:laszip_set_chunk_size, laszip), laszip_I32, (laszip_POINTER, laszip_U32), pointer, chunk_size)
+# function laszip_set_chunk_size(pointer::Ptr{Cvoid}, chunk_size::UInt32)
+#     ccall((:laszip_set_chunk_size, laszip), Int32, (Ptr{Cvoid}, UInt32), pointer, chunk_size)
 # end
 
-function laszip_open_writer(pointer::laszip_POINTER, file_name, compress::laszip_BOOL)
-    ccall((:laszip_open_writer, laszip), laszip_I32, (laszip_POINTER, Ptr{laszip_CHAR}, laszip_BOOL), pointer, file_name, compress)
+function laszip_open_writer(pointer::Ptr{Cvoid}, file_name, compress::Cint)
+    ccall((:laszip_open_writer, laszip), Int32, (Ptr{Cvoid}, Ptr{UInt8}, Cint), pointer, file_name, compress)
 end
 
-function laszip_write_point(pointer::laszip_POINTER)
-    ccall((:laszip_write_point, laszip), laszip_I32, (laszip_POINTER,), pointer)
+function laszip_write_point(pointer::Ptr{Cvoid})
+    ccall((:laszip_write_point, laszip), Int32, (Ptr{Cvoid},), pointer)
 end
 
-# function laszip_write_indexed_point(pointer::laszip_POINTER)
-#     ccall((:laszip_write_indexed_point, laszip), laszip_I32, (laszip_POINTER,), pointer)
+# function laszip_write_indexed_point(pointer::Ptr{Cvoid})
+#     ccall((:laszip_write_indexed_point, laszip), Int32, (Ptr{Cvoid},), pointer)
 # end
 
-function laszip_update_inventory(pointer::laszip_POINTER)
-    ccall((:laszip_update_inventory, laszip), laszip_I32, (laszip_POINTER,), pointer)
+function laszip_update_inventory(pointer::Ptr{Cvoid})
+    ccall((:laszip_update_inventory, laszip), Int32, (Ptr{Cvoid},), pointer)
 end
 
-function laszip_close_writer(pointer::laszip_POINTER)
-    ccall((:laszip_close_writer, laszip), laszip_I32, (laszip_POINTER,), pointer)
+function laszip_close_writer(pointer::Ptr{Cvoid})
+    ccall((:laszip_close_writer, laszip), Int32, (Ptr{Cvoid},), pointer)
 end
 
-# function laszip_exploit_spatial_index(pointer::laszip_POINTER, exploit::laszip_BOOL)
-#     ccall((:laszip_exploit_spatial_index, laszip), laszip_I32, (laszip_POINTER, laszip_BOOL), pointer, exploit)
+# function laszip_exploit_spatial_index(pointer::Ptr{Cvoid}, exploit::Cint)
+#     ccall((:laszip_exploit_spatial_index, laszip), Int32, (Ptr{Cvoid}, Cint), pointer, exploit)
 # end
 
-# function laszip_decompress_selective(pointer::laszip_POINTER, decompress_selective::laszip_U32)
-#     ccall((:laszip_decompress_selective, laszip), laszip_I32, (laszip_POINTER, laszip_U32), pointer, decompress_selective)
+# function laszip_decompress_selective(pointer::Ptr{Cvoid}, decompress_selective::UInt32)
+#     ccall((:laszip_decompress_selective, laszip), Int32, (Ptr{Cvoid}, UInt32), pointer, decompress_selective)
 # end
 
-function laszip_open_reader(pointer::laszip_POINTER, file_name, is_compressed)
-    ccall((:laszip_open_reader, laszip), laszip_I32, (laszip_POINTER, Ptr{laszip_CHAR}, Ptr{laszip_BOOL}), pointer, file_name, is_compressed)
+function laszip_open_reader(pointer::Ptr{Cvoid}, file_name, is_compressed)
+    ccall((:laszip_open_reader, laszip), Int32, (Ptr{Cvoid}, Ptr{UInt8}, Ptr{Cint}), pointer, file_name, is_compressed)
 end
 
-# function laszip_has_spatial_index(pointer::laszip_POINTER, is_indexed, is_appended)
-#     ccall((:laszip_has_spatial_index, laszip), laszip_I32, (laszip_POINTER, Ptr{laszip_BOOL}, Ptr{laszip_BOOL}), pointer, is_indexed, is_appended)
+# function laszip_has_spatial_index(pointer::Ptr{Cvoid}, is_indexed, is_appended)
+#     ccall((:laszip_has_spatial_index, laszip), Int32, (Ptr{Cvoid}, Ptr{Cint}, Ptr{Cint}), pointer, is_indexed, is_appended)
 # end
 
-# function laszip_inside_rectangle(pointer::laszip_POINTER, min_x::laszip_F64, min_y::laszip_F64, max_x::laszip_F64, max_y::laszip_F64, is_empty)
-#     ccall((:laszip_inside_rectangle, laszip), laszip_I32, (laszip_POINTER, laszip_F64, laszip_F64, laszip_F64, laszip_F64, Ptr{laszip_BOOL}), pointer, min_x, min_y, max_x, max_y, is_empty)
+# function laszip_inside_rectangle(pointer::Ptr{Cvoid}, min_x::Float64, min_y::Float64, max_x::Float64, max_y::Float64, is_empty)
+#     ccall((:laszip_inside_rectangle, laszip), Int32, (Ptr{Cvoid}, Float64, Float64, Float64, Float64, Ptr{Cint}), pointer, min_x, min_y, max_x, max_y, is_empty)
 # end
 
-function laszip_seek_point(pointer::laszip_POINTER, index::laszip_I64)
-    ccall((:laszip_seek_point, laszip), laszip_I32, (laszip_POINTER, laszip_I64), pointer, index)
+function laszip_seek_point(pointer::Ptr{Cvoid}, index::Int64)
+    ccall((:laszip_seek_point, laszip), Int32, (Ptr{Cvoid}, Int64), pointer, index)
 end
 
-function laszip_read_point(pointer::laszip_POINTER)
-    ccall((:laszip_read_point, laszip), laszip_I32, (laszip_POINTER,), pointer)
+function laszip_read_point(pointer::Ptr{Cvoid})
+    ccall((:laszip_read_point, laszip), Int32, (Ptr{Cvoid},), pointer)
 end
 
-# function laszip_read_inside_point(pointer::laszip_POINTER, is_done)
-#     ccall((:laszip_read_inside_point, laszip), laszip_I32, (laszip_POINTER, Ptr{laszip_BOOL}), pointer, is_done)
+# function laszip_read_inside_point(pointer::Ptr{Cvoid}, is_done)
+#     ccall((:laszip_read_inside_point, laszip), Int32, (Ptr{Cvoid}, Ptr{Cint}), pointer, is_done)
 # end
 
-function laszip_close_reader(pointer::laszip_POINTER)
-    ccall((:laszip_close_reader, laszip), laszip_I32, (laszip_POINTER,), pointer)
+function laszip_close_reader(pointer::Ptr{Cvoid})
+    ccall((:laszip_close_reader, laszip), Int32, (Ptr{Cvoid},), pointer)
 end

--- a/src/laszip.jl
+++ b/src/laszip.jl
@@ -313,11 +313,11 @@ function laszip_destroy(pointer::Ptr{Cvoid})
 end
 
 function laszip_get_header_pointer(pointer::Ptr{Cvoid}, header_pointer)
-    ccall((:laszip_get_header_pointer, laszip), Int32, (Ptr{Cvoid}, Ref{Ptr{laszip_header}}), pointer, header_pointer)
+    ccall((:laszip_get_header_pointer, laszip), Int32, (Ptr{Cvoid}, Ref{Ptr{LazHeader}}), pointer, header_pointer)
 end
 
 function laszip_get_point_pointer(pointer::Ptr{Cvoid}, point_pointer)
-    ccall((:laszip_get_point_pointer, laszip), Int32, (Ptr{Cvoid}, Ref{Ptr{laszip_point}}), pointer, point_pointer)
+    ccall((:laszip_get_point_pointer, laszip), Int32, (Ptr{Cvoid}, Ref{Ptr{LazPoint}}), pointer, point_pointer)
 end
 
 function laszip_get_point_count(pointer::Ptr{Cvoid}, count)
@@ -325,7 +325,7 @@ function laszip_get_point_count(pointer::Ptr{Cvoid}, count)
 end
 
 function laszip_set_header(pointer::Ptr{Cvoid}, header)
-    ccall((:laszip_set_header, laszip), Int32, (Ptr{Cvoid}, Ptr{laszip_header}), pointer, header)
+    ccall((:laszip_set_header, laszip), Int32, (Ptr{Cvoid}, Ptr{LazHeader}), pointer, header)
 end
 
 # function laszip_set_point_type_and_size(pointer::Ptr{Cvoid}, point_type::UInt8, point_size::UInt16)
@@ -341,7 +341,7 @@ end
 # end
 
 function laszip_set_point(pointer::Ptr{Cvoid}, point)
-    ccall((:laszip_set_point, laszip), Int32, (Ptr{Cvoid}, Ptr{laszip_point}), pointer, point)
+    ccall((:laszip_set_point, laszip), Int32, (Ptr{Cvoid}, Ptr{LazPoint}), pointer, point)
 end
 
 # function laszip_set_coordinates(pointer::Ptr{Cvoid}, coordinates)

--- a/src/laszip_h.jl
+++ b/src/laszip_h.jl
@@ -9,8 +9,6 @@ using Parameters
     value_offset::UInt16 = UInt16(0)
 end
 
-const laszip_geokey_struct = Nothing
-
 @with_kw mutable struct laszip_vlr
     reserved::UInt16 = UInt16(0)
     user_id::NTuple{16, UInt8} = ntuple(i -> UInt8(0x0), 16)
@@ -19,8 +17,6 @@ const laszip_geokey_struct = Nothing
     description::NTuple{32, UInt8} = ntuple(i -> UInt8(0x0), 32)
     data::Ptr{UInt8} = pointer("")
 end
-
-const laszip_vlr_struct = Nothing
 
 @with_kw mutable struct laszip_header
     file_source_ID::UInt16 = UInt16(0)
@@ -66,7 +62,7 @@ const laszip_vlr_struct = Nothing
     # extended_number_of_points_by_return::Array{UInt64, 1} = Array{UInt64, 1}(zeros(0, 15))
     user_data_in_header_size::UInt32 = UInt32(0)
     user_data_in_header::Ptr{UInt8} = pointer("")
-    vlrs::Ptr{laszip_vlr_struct} = pointer("")
+    vlrs::Ptr{Cvoid} = pointer("")
     user_data_after_header_size::UInt32 = UInt32(0)
     user_data_after_header::Ptr{UInt8} = pointer("")
 end

--- a/src/laszip_h.jl
+++ b/src/laszip_h.jl
@@ -27,7 +27,7 @@ const laszip_I64 = Int64
 const laszip_CHAR = UInt8
 const laszip_F32 = Cfloat
 const laszip_F64 = Cdouble
-const laszip_POINTER = Ptr{Nothing}
+const laszip_POINTER = Ptr{Cvoid}
 
 @with_kw mutable struct laszip_geokey
     key_id::laszip_U16 = laszip_U16(0)

--- a/src/laszip_h.jl
+++ b/src/laszip_h.jl
@@ -3,18 +3,6 @@
 using Compat
 using Parameters
 
-const __darwin_va_list = Cstring
-const __darwin_off_t = Int64
-const __darwin_size_t = Culong
-const __darwin_ssize_t = Clong
-const __darwin_intptr_t = Clong
-const size_t = __darwin_size_t
-const fpos_t = __darwin_off_t
-const FILE = Nothing
-const va_list = __darwin_va_list
-const off_t = __darwin_off_t
-const ssize_t = __darwin_ssize_t
-
 @with_kw mutable struct laszip_geokey
     key_id::UInt16 = UInt16(0)
     tiff_tag_location::UInt16 = UInt16(0)

--- a/src/laszip_h.jl
+++ b/src/laszip_h.jl
@@ -15,94 +15,80 @@ const va_list = __darwin_va_list
 const off_t = __darwin_off_t
 const ssize_t = __darwin_ssize_t
 
-const laszip_BOOL = Cint
-const laszip_U8 = UInt8
-const laszip_U16 = UInt16
-const laszip_U32 = UInt32
-const laszip_U64 = UInt64
-const laszip_I8 = Int8
-const laszip_I16 = Int16
-const laszip_I32 = Int32
-const laszip_I64 = Int64
-const laszip_CHAR = UInt8
-const laszip_F32 = Cfloat
-const laszip_F64 = Cdouble
-const laszip_POINTER = Ptr{Cvoid}
-
 @with_kw mutable struct laszip_geokey
-    key_id::laszip_U16 = laszip_U16(0)
-    tiff_tag_location::laszip_U16 = laszip_U16(0)
-    count::laszip_U16 = laszip_U16(0)
-    value_offset::laszip_U16 = laszip_U16(0)
+    key_id::UInt16 = UInt16(0)
+    tiff_tag_location::UInt16 = UInt16(0)
+    count::UInt16 = UInt16(0)
+    value_offset::UInt16 = UInt16(0)
 end
 
 const laszip_geokey_struct = Nothing
 
 @with_kw mutable struct laszip_vlr
-    reserved::laszip_U16 = laszip_U16(0)
-    user_id::NTuple{16, laszip_CHAR} = ntuple(i -> laszip_CHAR(0x0), 16)
-    record_id::laszip_U16 = laszip_U16(0)
-    record_length_after_header::laszip_U16 = laszip_U16(0)
-    description::NTuple{32, laszip_CHAR} = ntuple(i -> laszip_CHAR(0x0), 32)
-    data::Ptr{laszip_U8} = pointer("")
+    reserved::UInt16 = UInt16(0)
+    user_id::NTuple{16, UInt8} = ntuple(i -> UInt8(0x0), 16)
+    record_id::UInt16 = UInt16(0)
+    record_length_after_header::UInt16 = UInt16(0)
+    description::NTuple{32, UInt8} = ntuple(i -> UInt8(0x0), 32)
+    data::Ptr{UInt8} = pointer("")
 end
 
 const laszip_vlr_struct = Nothing
 
 @with_kw mutable struct laszip_header
-    file_source_ID::laszip_U16 = laszip_U16(0)
-    global_encoding::laszip_U16 = laszip_U16(0)
-    project_ID_GUID_data_1::laszip_U32 = laszip_U32(0)
-    project_ID_GUID_data_2::laszip_U16 = laszip_U16(0)
-    project_ID_GUID_data_3::laszip_U16 = laszip_U16(0)
-    project_ID_GUID_data_4::NTuple{8, laszip_CHAR} = ntuple(i -> laszip_CHAR(20), 8)
-    # project_ID_GUID_data_4::Array{laszip_CHAR, 1} = Array{laszip_CHAR, 1}(zeros(0, 8))
-    version_major::laszip_U8 = laszip_U8(0)
-    version_minor::laszip_U8 = laszip_U8(0)
-    system_identifier::NTuple{32, laszip_CHAR} = ntuple(i -> laszip_CHAR(20), 32)
-    # system_identifier::Array{laszip_CHAR} = Array{laszip_CHAR}(32)
-    generating_software::NTuple{32, laszip_CHAR} = ntuple(i -> laszip_CHAR(20), 32)
-    # generating_software::Array{laszip_CHAR, 1} = Array{laszip_CHAR, 1}(zeros(0, 32))
-    file_creation_day::laszip_U16 = laszip_U16(0)
-    file_creation_year::laszip_U16 = laszip_U16(0)
-    header_size::laszip_U16 = laszip_U16(0)
-    offset_to_point_data::laszip_U32 = laszip_U32(0)
-    number_of_variable_length_records::laszip_U32 = laszip_U32(0)
-    point_data_format::laszip_U8 = laszip_U8(0)
-    point_data_record_length::laszip_U16 = laszip_U16(0)
-    number_of_point_records::laszip_U32 = laszip_U32(0)
-    number_of_points_by_return::NTuple{5, laszip_U32} = ntuple(i -> laszip_U32(0), 5)
-    # number_of_points_by_return::Array{laszip_U32, 1} = Array{laszip_U32, 1}(zeros(0, 5))
-    x_scale_factor::laszip_F64 = laszip_F64(0.0)
-    y_scale_factor::laszip_F64 = laszip_F64(0.0)
-    z_scale_factor::laszip_F64 = laszip_F64(0.0)
-    x_offset::laszip_F64 = laszip_F64(0.0)
-    y_offset::laszip_F64 = laszip_F64(0.0)
-    z_offset::laszip_F64 = laszip_F64(0.0)
-    max_x::laszip_F64 = laszip_F64(0.0)
-    min_x::laszip_F64 = laszip_F64(0.0)
-    max_y::laszip_F64 = laszip_F64(0.0)
-    min_y::laszip_F64 = laszip_F64(0.0)
-    max_z::laszip_F64 = laszip_F64(0.0)
-    min_z::laszip_F64 = laszip_F64(0.0)
-    start_of_waveform_data_packet_record::laszip_U64  = laszip_U64(0)
-    start_of_first_extended_variable_length_record::laszip_U64 = laszip_U64(0)
-    number_of_extended_variable_length_records::laszip_U32 = laszip_U32(0)
-    extended_number_of_point_records::laszip_U64 = laszip_U64(0)
-    extended_number_of_points_by_return::NTuple{15, laszip_U64} = ntuple(i -> laszip_U64(0), 15)
-    # extended_number_of_points_by_return::Array{laszip_U64, 1} = Array{laszip_U64, 1}(zeros(0, 15))
-    user_data_in_header_size::laszip_U32 = laszip_U32(0)
-    user_data_in_header::Ptr{laszip_U8} = pointer("")
+    file_source_ID::UInt16 = UInt16(0)
+    global_encoding::UInt16 = UInt16(0)
+    project_ID_GUID_data_1::UInt32 = UInt32(0)
+    project_ID_GUID_data_2::UInt16 = UInt16(0)
+    project_ID_GUID_data_3::UInt16 = UInt16(0)
+    project_ID_GUID_data_4::NTuple{8, UInt8} = ntuple(i -> UInt8(20), 8)
+    # project_ID_GUID_data_4::Array{UInt8, 1} = Array{UInt8, 1}(zeros(0, 8))
+    version_major::UInt8 = UInt8(0)
+    version_minor::UInt8 = UInt8(0)
+    system_identifier::NTuple{32, UInt8} = ntuple(i -> UInt8(20), 32)
+    # system_identifier::Array{UInt8} = Array{UInt8}(32)
+    generating_software::NTuple{32, UInt8} = ntuple(i -> UInt8(20), 32)
+    # generating_software::Array{UInt8, 1} = Array{UInt8, 1}(zeros(0, 32))
+    file_creation_day::UInt16 = UInt16(0)
+    file_creation_year::UInt16 = UInt16(0)
+    header_size::UInt16 = UInt16(0)
+    offset_to_point_data::UInt32 = UInt32(0)
+    number_of_variable_length_records::UInt32 = UInt32(0)
+    point_data_format::UInt8 = UInt8(0)
+    point_data_record_length::UInt16 = UInt16(0)
+    number_of_point_records::UInt32 = UInt32(0)
+    number_of_points_by_return::NTuple{5, UInt32} = ntuple(i -> UInt32(0), 5)
+    # number_of_points_by_return::Array{UInt32, 1} = Array{UInt32, 1}(zeros(0, 5))
+    x_scale_factor::Float64 = Float64(0.0)
+    y_scale_factor::Float64 = Float64(0.0)
+    z_scale_factor::Float64 = Float64(0.0)
+    x_offset::Float64 = Float64(0.0)
+    y_offset::Float64 = Float64(0.0)
+    z_offset::Float64 = Float64(0.0)
+    max_x::Float64 = Float64(0.0)
+    min_x::Float64 = Float64(0.0)
+    max_y::Float64 = Float64(0.0)
+    min_y::Float64 = Float64(0.0)
+    max_z::Float64 = Float64(0.0)
+    min_z::Float64 = Float64(0.0)
+    start_of_waveform_data_packet_record::UInt64  = UInt64(0)
+    start_of_first_extended_variable_length_record::UInt64 = UInt64(0)
+    number_of_extended_variable_length_records::UInt32 = UInt32(0)
+    extended_number_of_point_records::UInt64 = UInt64(0)
+    extended_number_of_points_by_return::NTuple{15, UInt64} = ntuple(i -> UInt64(0), 15)
+    # extended_number_of_points_by_return::Array{UInt64, 1} = Array{UInt64, 1}(zeros(0, 15))
+    user_data_in_header_size::UInt32 = UInt32(0)
+    user_data_in_header::Ptr{UInt8} = pointer("")
     vlrs::Ptr{laszip_vlr_struct} = pointer("")
-    user_data_after_header_size::laszip_U32 = laszip_U32(0)
-    user_data_after_header::Ptr{laszip_U8} = pointer("")
+    user_data_after_header_size::UInt32 = UInt32(0)
+    user_data_after_header::Ptr{UInt8} = pointer("")
 end
 
 @with_kw mutable struct laszip_point
-    X::laszip_I32 = laszip_I32(0)
-    Y::laszip_I32 = laszip_I32(0)
-    Z::laszip_I32 = laszip_I32(0)
-    intensity::laszip_U16 = laszip_U16(0)
+    X::Int32 = Int32(0)
+    Y::Int32 = Int32(0)
+    Z::Int32 = Int32(0)
+    intensity::UInt16 = UInt16(0)
 
     # Evil types
     # U8 return_number : 3;
@@ -113,17 +99,17 @@ end
     # U8 synthetic_flag : 1;
     # U8 keypoint_flag  : 1;
     # U8 withheld_flag : 1;      8
-    return_number::laszip_U8 = laszip_U8(0)
-    # number_of_returns::laszip_U8 = laszip_U8(0)
-    # scan_direction_flag::laszip_U8 = laszip_U8(0)
-    # edge_of_flight_line::laszip_U8 = laszip_U8(0)
-    classification::laszip_U8 = laszip_U8(0)
-    # synthetic_flag::laszip_U8 = laszip_U8(0)
-    # keypoint_flag::laszip_U8 = laszip_U8(0)
-    # withheld_flag::laszip_U8 = laszip_U8(0)
-    scan_angle_rank::laszip_I8 = laszip_I8(0)
-    user_data::laszip_U8 = laszip_U8(0)
-    point_source_ID::laszip_U16 = laszip_U16(0)
+    return_number::UInt8 = UInt8(0)
+    # number_of_returns::UInt8 = UInt8(0)
+    # scan_direction_flag::UInt8 = UInt8(0)
+    # edge_of_flight_line::UInt8 = UInt8(0)
+    classification::UInt8 = UInt8(0)
+    # synthetic_flag::UInt8 = UInt8(0)
+    # keypoint_flag::UInt8 = UInt8(0)
+    # withheld_flag::UInt8 = UInt8(0)
+    scan_angle_rank::Int8 = Int8(0)
+    user_data::UInt8 = UInt8(0)
+    point_source_ID::UInt16 = UInt16(0)
 
 
     # Another evil type
@@ -134,17 +120,17 @@ end
     # U8 extended_classification;
     # U8 extended_return_number : 4;
     # U8 extended_number_of_returns : 4;  8
-    extended_scan_angle::laszip_I16 = laszip_I16(0)
-    extended_point_type::laszip_U8 = laszip_U8(0)
-    # extended_scanner_channel::laszip_U8 = laszip_U8(0)
-    # extended_classification_flags::laszip_U8 = laszip_U8(0)
-    extended_classification::laszip_U8 = laszip_U8(0)
-    extended_return_number::laszip_U8 = laszip_U8(0)
-    # extended_number_of_returns::laszip_U8 = laszip_U8(0)
-    dummy::NTuple{7, laszip_U8} = ntuple(i -> laszip_U8(0), 7)
-    gps_time::laszip_F64 = laszip_F64(0.0)
-    rgb::NTuple{4, laszip_U16} = ntuple(i -> laszip_U16(0), 4)
-    wave_packet::NTuple{29, laszip_U8} = ntuple(i -> laszip_U8(0), 29)
-    num_extra_bytes::laszip_I32 = laszip_I32(0)
-    extra_bytes::Ptr{laszip_U8} = pointer("")
+    extended_scan_angle::Int16 = Int16(0)
+    extended_point_type::UInt8 = UInt8(0)
+    # extended_scanner_channel::UInt8 = UInt8(0)
+    # extended_classification_flags::UInt8 = UInt8(0)
+    extended_classification::UInt8 = UInt8(0)
+    extended_return_number::UInt8 = UInt8(0)
+    # extended_number_of_returns::UInt8 = UInt8(0)
+    dummy::NTuple{7, UInt8} = ntuple(i -> UInt8(0), 7)
+    gps_time::Float64 = Float64(0.0)
+    rgb::NTuple{4, UInt16} = ntuple(i -> UInt16(0), 4)
+    wave_packet::NTuple{29, UInt8} = ntuple(i -> UInt8(0), 29)
+    num_extra_bytes::Int32 = Int32(0)
+    extra_bytes::Ptr{UInt8} = pointer("")
 end

--- a/src/laszip_h.jl
+++ b/src/laszip_h.jl
@@ -1,6 +1,5 @@
 # Automatically generated using Clang.jl wrap_c, version 0.0.0
 
-using Compat
 using Parameters
 
 @with_kw mutable struct laszip_geokey

--- a/src/laszip_h.jl
+++ b/src/laszip_h.jl
@@ -2,14 +2,14 @@
 
 using Parameters
 
-@with_kw mutable struct laszip_geokey
+@with_kw mutable struct LazGeoKey
     key_id::UInt16 = UInt16(0)
     tiff_tag_location::UInt16 = UInt16(0)
     count::UInt16 = UInt16(0)
     value_offset::UInt16 = UInt16(0)
 end
 
-@with_kw mutable struct laszip_vlr
+@with_kw mutable struct LazVLR
     reserved::UInt16 = UInt16(0)
     user_id::NTuple{16, UInt8} = ntuple(i -> UInt8(0x0), 16)
     record_id::UInt16 = UInt16(0)
@@ -18,7 +18,7 @@ end
     data::Ptr{UInt8} = pointer("")
 end
 
-@with_kw mutable struct laszip_header
+@with_kw mutable struct LazHeader
     file_source_ID::UInt16 = UInt16(0)
     global_encoding::UInt16 = UInt16(0)
     project_ID_GUID_data_1::UInt32 = UInt32(0)
@@ -67,7 +67,7 @@ end
     user_data_after_header::Ptr{UInt8} = pointer("")
 end
 
-@with_kw mutable struct laszip_point
+@with_kw mutable struct LazPoint
     X::Int32 = Int32(0)
     Y::Int32 = Int32(0)
     Z::Int32 = Int32(0)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,4 +1,4 @@
-function laszip_error(laszip_obj::Ptr{Nothing})
+function laszip_error(laszip_obj::Ptr{Cvoid})
     errstr = Ref(Cstring(C_NULL))
     laszip_get_error(laszip_obj, errstr)
     if errstr[] != C_NULL

--- a/src/write.jl
+++ b/src/write.jl
@@ -16,7 +16,7 @@ function write(f::Function, path::AbstractString, ds::LazIO.LazDataset)
     end
 end
 
-function write(f::Function, path::AbstractString, header::LazIO.laszip_header)
+function write(f::Function, path::AbstractString, header::LazIO.LazHeader)
     # create writer
     writer = Ref{Ptr{Cvoid}}(C_NULL)
     LazIO.@check writer[] LazIO.laszip_create(writer)
@@ -33,7 +33,7 @@ function write(f::Function, path::AbstractString, header::LazIO.laszip_header)
     end
 end
 
-function writepoint(writer::Ptr{Cvoid}, p::LazIO.laszip_point)
+function writepoint(writer::Ptr{Cvoid}, p::LazIO.LazPoint)
     LazIO.@check writer LazIO.laszip_set_point(writer, Ref(p))
     LazIO.@check writer LazIO.laszip_write_point(writer)
     LazIO.@check writer LazIO.laszip_update_inventory(writer)

--- a/test/testio.jl
+++ b/test/testio.jl
@@ -35,7 +35,7 @@ end
 @testset "LazDataSet" begin
     ds = LazIO.open(testfile_str)
     @test ds isa LazIO.LazDataset
-    @test first(ds) isa LazIO.laszip_point
+    @test first(ds) isa LazIO.LazPoint
     @inferred first(ds)
     close(ds)
 end
@@ -51,7 +51,7 @@ end
     LazIO.@check writer[] LazIO.laszip_create(writer)
 
     # copy header from reader to writer (to be updated later)
-    header_ptr = Ref{Ptr{LazIO.laszip_header}}(C_NULL)
+    header_ptr = Ref{Ptr{LazIO.LazHeader}}(C_NULL)
     LazIO.@check header_ptr[] LazIO.laszip_get_header_pointer(reader[], header_ptr)
     LazIO.@check writer[] LazIO.laszip_set_header(writer[], header_ptr[])
 
@@ -59,7 +59,7 @@ end
     LazIO.@check writer[] LazIO.laszip_open_writer(writer[], laz_out, Cint(1))
 
     # read the first point
-    point_ptr = Ref{Ptr{LazIO.laszip_point}}(C_NULL)
+    point_ptr = Ref{Ptr{LazIO.LazPoint}}(C_NULL)
     LazIO.@check point_ptr[] LazIO.laszip_get_point_pointer(reader[], point_ptr)
     LazIO.@check reader[] LazIO.laszip_read_point(reader[])
 


### PR DESCRIPTION
Grab bag of things that were in the old `wop` branch. Most significantly renaming the struct from `laszip_point` and `laszip_header` to `LasPoint` and `LazHeader`.