### PR TITLE
reinterpret UInt16 colors as FixedPointNumbers

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "0.1.2"
 [deps]
 BinaryProvider = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
+FixedPointNumbers = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
 LasIO = "570499db-eae3-5eb6-bdd5-a5326f375e68"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 Parameters = "d96e819e-fc66-5662-9728-84c9c7592b0a"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LazIO"
 uuid = "c3605908-9f0f-11e8-0a72-0d361c15a277"
 authors = ["Maarten Pronk <git@evetion.nl>"]
-version = "0.1.2"
+version = "0.1.3"
 
 [deps]
 BinaryProvider = "b99e7846-7c00-51b0-8f62-c81ae34c0232"

--- a/src/LazIO.jl
+++ b/src/LazIO.jl
@@ -3,6 +3,7 @@ module LazIO
 using Libdl
 using FileIO
 using LasIO
+using FixedPointNumbers
 
 # Load in `deps.jl`, complaining if it does not exist
 const depsjl_path = joinpath(dirname(@__FILE__), "..", "deps", "deps.jl")

--- a/src/convert.jl
+++ b/src/convert.jl
@@ -79,9 +79,9 @@ Base.convert(::Type{LasPoint2}, p::LazPoint) =
         p.scan_angle_rank,
         p.user_data,
         p.point_source_ID,
-        p.rgb[1],
-        p.rgb[2],
-        p.rgb[3]
+        reinterpret(N0f16, p.rgb[1]),
+        reinterpret(N0f16, p.rgb[2]),
+        reinterpret(N0f16, p.rgb[3])
     )
 
 "ASPRS LAS point data record format 3"
@@ -97,7 +97,7 @@ Base.convert(::Type{LasPoint3}, p::LazPoint) =
         p.user_data,
         p.point_source_ID,
         p.gps_time,
-        p.rgb[1],
-        p.rgb[2],
-        p.rgb[3]
+        reinterpret(N0f16, p.rgb[1]),
+        reinterpret(N0f16, p.rgb[2]),
+        reinterpret(N0f16, p.rgb[3])
     )

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,4 +2,5 @@ using Test
 
 @testset "LazIO" begin
     include("testio.jl")
+    include("test_convert.jl")
 end

--- a/test/test_convert.jl
+++ b/test/test_convert.jl
@@ -1,0 +1,68 @@
+using Test
+using LazIO
+
+@testset "Conversion" begin
+    # test with maximum fields where applicable
+    lazp = LazIO.LazPoint(
+        X = Int32(5000),
+        Y = Int32(6000),
+        Z = Int32(7000),
+        intensity = UInt16(65535),
+
+        # Evil types
+        # U8 return_number : 3;
+        # U8 number_of_returns : 3;
+        # U8 scan_direction_flag : 1;
+        # U8 edge_of_flight_line : 1;  8
+        # U8 classification : 5;
+        # U8 synthetic_flag : 1;
+        # U8 keypoint_flag  : 1;
+        # U8 withheld_flag : 1;      8
+        return_number = UInt8(255),
+        # number_of_returns = UInt8(0),
+        # scan_direction_flag = UInt8(0),
+        # edge_of_flight_line = UInt8(0),
+        classification = UInt8(255),
+        # synthetic_flag = UInt8(0),
+        # keypoint_flag = UInt8(0),
+        # withheld_flag = UInt8(0),
+        scan_angle_rank = Int8(127),
+        user_data = UInt8(255),
+        point_source_ID = UInt16(65535),
+
+
+        # Another evil type
+        # I16 extended_scan_angle;
+        # U8 extended_point_type : 2;
+        # U8 extended_scanner_channel : 2;
+        # U8 extended_classification_flags : 4;  8
+        # U8 extended_classification;
+        # U8 extended_return_number : 4;
+        # U8 extended_number_of_returns : 4;  8
+        extended_scan_angle = Int16(32767),
+        extended_point_type = UInt8(255),
+        # extended_scanner_channel = UInt8(0),
+        # extended_classification_flags = UInt8(0),
+        extended_classification = UInt8(255),
+        extended_return_number = UInt8(25),
+        # extended_number_of_returns = UInt8(0),
+        dummy = ntuple(i -> UInt8(255), 7),
+        gps_time = Float64(8791823.25),
+        rgb = ntuple(i -> UInt16(65535), 4),
+        wave_packet = ntuple(i -> UInt8(255), 29),
+        num_extra_bytes = Int32(24244),
+        extra_bytes = pointer("")
+    )
+
+    las0 = convert(LazIO.LasPoint0, lazp)
+    las1 = convert(LazIO.LasPoint1, lazp)
+    las2 = convert(LazIO.LasPoint2, lazp)
+    las3 = convert(LazIO.LasPoint3, lazp)
+
+    # test with all zero fields
+    lazp = LazIO.LazPoint()
+    las0 = convert(LazIO.LasPoint0, lazp)
+    las1 = convert(LazIO.LasPoint1, lazp)
+    las2 = convert(LazIO.LasPoint2, lazp)
+    las3 = convert(LazIO.LasPoint3, lazp)
+end


### PR DESCRIPTION
N0f16 is the type that is used to represent color channels in LasIO.

This fixes `LazIO.load` for point type 2 and 3, which would fail with:

```
ArgumentError: FixedPointNumbers.Normed{UInt16,16} is a 16-bit type representing 65536 values from 0.0 to 1.0; cannot represent 7168
```